### PR TITLE
Fix mobile gallery: stack tiles vertically with 4:3 aspect ratio

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -20,6 +20,16 @@
   .scroll-visible { transition: none; }
 }
 
+/* Mobile gallery: full-width cells with square-ish aspect ratio */
+@media (max-width: 639px) {
+  .gallery-cell {
+    width: 100% !important;
+    height: auto !important;
+    aspect-ratio: 4 / 3;
+    flex-shrink: 0;
+  }
+}
+
 @font-face {
   font-family: 'Amsterdam Two';
   src: url('/fonts/amsterdamtwottf-ovmee.ttf') format('truetype');

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -309,11 +309,11 @@ export default function LinasoulPortfolio() {
               {galleryRows.map((row, idx) => (
                 <div
                   key={idx}
-                  className="flex gap-3 sm:gap-4 scroll-hidden"
+                  className="flex flex-col sm:flex-row gap-3 sm:gap-4 scroll-hidden"
                   style={{ transitionDelay: `${idx * 0.1}s` }}
                 >
                   <div
-                    className={row.lImg ? "overflow-hidden rounded-3xl group cursor-zoom-in" : "flex flex-col items-center justify-center px-6 text-center rounded-3xl bg-slate-50/60"}
+                    className={row.lImg ? "overflow-hidden rounded-3xl group cursor-zoom-in gallery-cell" : "flex flex-col items-center justify-center px-6 text-center rounded-3xl bg-slate-50/60 gallery-cell"}
                     style={{ width: row.lw, height: row.h, flexShrink: 0 }}
                     onClick={row.lImg ? () => { setZoomSrc(row.lImg!.src); setZoomLevel(1) } : undefined}
                   >
@@ -327,7 +327,7 @@ export default function LinasoulPortfolio() {
                     ) : null}
                   </div>
                   <div
-                    className={row.rImg ? "overflow-hidden rounded-3xl group cursor-zoom-in" : "flex flex-col items-center justify-center px-6 text-center rounded-3xl bg-slate-50/60"}
+                    className={row.rImg ? "overflow-hidden rounded-3xl group cursor-zoom-in gallery-cell" : "flex flex-col items-center justify-center px-6 text-center rounded-3xl bg-slate-50/60 gallery-cell"}
                     style={{ flex: 1, height: row.h }}
                     onClick={row.rImg ? () => { setZoomSrc(row.rImg!.src); setZoomLevel(1) } : undefined}
                   >


### PR DESCRIPTION
On mobile tiles now stack single-column with proportional aspect ratio instead of side-by-side elongated layout.

https://claude.ai/code/session_01CcPDxMRYeYJr5UZBwjHGkK